### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,4 +1,6 @@
 name: PR Test Build
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ZalithLauncher/ZalithWebsite/security/code-scanning/1](https://github.com/ZalithLauncher/ZalithWebsite/security/code-scanning/1)

To fix this problem, explicitly set the permissions for the job, or for the workflow as a whole, to the minimum required. Since the shown workflow steps only need to read the repository (to checkout files), you should set `permissions: contents: read`. This can be done either globally at the root of the workflow file (applying to all jobs), or inside the specific job. The best approach for clarity and future extensibility is to add it at the top-level, immediately after the workflow `name` and before `on:`. No other code changes or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
