### PR TITLE
fix: cleanup download sources — remove Fishcpy/Foxington, add 创想镜像

### DIFF
--- a/public/build-info.json
+++ b/public/build-info.json
@@ -1,7 +1,7 @@
 {
-  "commitHash": "be22bae",
-  "commitDate": "2026-08-17T21:59:22+08:00",
-  "branch": "main",
-  "buildTime": "2026-08-20T02:57:39.265Z",
+  "commitHash": "386ff12",
+  "commitDate": "2026-08-20T11:06:41+08:00",
+  "branch": "fix/download-sources-cleanup",
+  "buildTime": "2026-08-20T03:17:46.495Z",
   "repoUrl": "https://github.com/ZalithLauncher/ZalithWebsite"
 }

--- a/src/components/Download.tsx
+++ b/src/components/Download.tsx
@@ -146,21 +146,21 @@ const DownloadSection = () => {
   const lemwoodSiteBase = LEMWOOD_API_BASE.replace('/api/v2', '');
 
   const getDownloadUrl = (asset: Asset) => {
-    const tagName = release?.tag_name || '';
-    
-    if (selectedSource === 'mirror') {
-      const version = activeProject === 'zl1' ? tagName.replace('v', '').replace(/\./g, '') : tagName.replace('v', '');
-      return `https://download.fishcpy.top/dl/${activeProject === 'zl1' ? 'zl' : 'zl2'}/${version}/${asset.name}`;
-    }
-
-    if (selectedSource === 'foxington' && Array.isArray(mirrorData.foxington)) {
+    if (selectedSource === 'cxsj') {
+      // 创想镜像：URL 格式固定为 https://mirror.cxsjmc.cn/ZL/ZalithLauncher-latest-{arch}.apk
+      // 仅支持 ZL2，ZL1 回退到 GitHub
+      if (activeProject !== 'zl2') return asset.browser_download_url;
       const fileName = asset.name.toLowerCase();
-      let targetArch = 'all 架构';
-      if (fileName.includes('arm64')) targetArch = 'arm64-v8a 架构';
-      else if (fileName.includes('armeabi')) targetArch = 'armeabi-v7a 架构';
-      
-      const matched = mirrorData.foxington.find((f: MirrorAsset) => f.name === targetArch);
-      return matched?.url || asset.browser_download_url;
+      let archPart = '';
+      if (fileName.includes('arm64-v8a') || fileName.includes('arm64')) archPart = 'arm64-v8a';
+      else if (fileName.includes('armeabi-v7a') || fileName.includes('armeabi')) archPart = 'armeabi-v7a';
+      else if (fileName.includes('x86_64') || fileName.includes('x86-64')) archPart = 'x86_64';
+      else if (fileName.includes('x86')) archPart = 'x86';
+      // 通用版本文件名不含架构后缀
+      const file = archPart
+        ? `ZalithLauncher-latest-${archPart}.apk`
+        : `ZalithLauncher-latest.apk`;
+      return `https://mirror.cxsjmc.cn/ZL/${file}`;
     }
 
     if (selectedSource === 'haha' && Array.isArray(mirrorData.haha)) {

--- a/src/hooks/useLatestRelease.ts
+++ b/src/hooks/useLatestRelease.ts
@@ -86,17 +86,15 @@ export interface VersionJsonData {
 }
 
 export interface MirrorData {
-  foxington: MirrorAsset[] | null;
   haha: MirrorAsset[] | null;
   lemwood: MirrorRelease[] | null;
 }
 
 const DOWNLOAD_SOURCES: DownloadSource[] = [
   { id: 'github', name: 'GitHub 官方', description: '官方发布渠道', speed: '海外较快' },
-  { id: 'mirror', name: 'Fishcpy 加速', description: 'fishcpy 提供', speed: '国内较快', contributor: { name: 'fishcpy', url: 'https://github.com/fishcpy' } },
-  { id: 'foxington', name: 'Foxington 源', description: '第三方镜像', speed: '国内较快', contributor: { name: 'XiaoluoFoxington', url: 'https://github.com/XiaoluoFoxington' } },
   { id: 'haha', name: '枫源镜像', description: 'FrostLynx 提供', speed: '国内较快', contributor: { name: 'FrostLynx', url: 'https://fyhub.cn' } },
   { id: 'lemwood', name: '柠泽资源站', description: 'Lemwood 提供', speed: '国内较快', contributor: { name: 'Lemwood', url: 'https://lemwood.cn' } },
+  { id: 'cxsj', name: '创想镜像', description: '239LAN 提供', speed: '国内较快', contributor: { name: '创想镜像', url: 'https://mirror.cxsjmc.cn' } },
 ];
 
 function filterMappingAssets(release: Release): Release {
@@ -122,7 +120,7 @@ export const useLatestRelease = (project: 'zl1' | 'zl2', currentLang: string) =>
   const [apiFailed, setApiFailed] = useState(false);
   const [versionJsonData, setVersionJsonData] = useState<VersionJsonData | null>(null);
 
-  const [mirrorData, setMirrorData] = useState<MirrorData>({ foxington: null, haha: null, lemwood: null });
+  const [mirrorData, setMirrorData] = useState<MirrorData>({ haha: null, lemwood: null });
 
   const repo = project === 'zl1' ? 'ZalithLauncher/ZalithLauncher' : 'ZalithLauncher/ZalithLauncher2';
   const localVersionFile = project === 'zl1' ? '/version.json' : '/version2.json';
@@ -241,7 +239,6 @@ export const useLatestRelease = (project: 'zl1' | 'zl2', currentLang: string) =>
       };
 
       const fetchMirrorsTask = async () => {
-        const foxingtonUrl = project === 'zl1' ? 'https://next.foldcraftlauncher.cn/data/down/zl/1/1.4.1.0/index.json' : null;
         // 枫源镜像新站 fyhub.cn：项目 ID 使用仓库名，且仅收录 ZalithLauncher2（ZL1 已下架）
         const hahaUrl = project === 'zl2' ? 'https://fyhub.cn/api/public/v1/projects/ZalithLauncher2/assets' : null;
         const lemwoodUrl = `${LEMWOOD_API_BASE}/launchers/${project === 'zl1' ? 'zl' : 'zl2'}`;
@@ -286,14 +283,13 @@ export const useLatestRelease = (project: 'zl1' | 'zl2', currentLang: string) =>
           }
         };
 
-        const [fox, ha, lem] = await Promise.all([
-          foxingtonUrl ? fetchJson(foxingtonUrl) : Promise.resolve(null),
+        const [ha, lem] = await Promise.all([
           hahaUrl ? fetchJson(hahaUrl) : Promise.resolve(null),
           fetchJson(lemwoodUrl)
         ]);
 
         if (isMounted) {
-          const newMirrorData = { foxington: fox, haha: ha, lemwood: lem };
+          const newMirrorData = { haha: ha, lemwood: lem };
           setMirrorData(newMirrorData);
           localStorage.setItem(`${cacheKeyPrefix}mirrors`, JSON.stringify(newMirrorData));
           setIsMirrorsLoading(false);
@@ -431,9 +427,9 @@ export const useLatestRelease = (project: 'zl1' | 'zl2', currentLang: string) =>
     return versionJsonData.default_cloud_drive || null;
   }, [versionJsonData, project]);
 
-  // 枫源镜像（新站 fyhub.cn）已下架 ZL1，ZL1 页面不再提供该下载源
+  // 枫源镜像（新站 fyhub.cn）已下架 ZL1，创想镜像仅支持 ZL2
   const downloadSources = useMemo(
-    () => (project === 'zl1' ? DOWNLOAD_SOURCES.filter(s => s.id !== 'haha') : DOWNLOAD_SOURCES),
+    () => (project === 'zl1' ? DOWNLOAD_SOURCES.filter(s => s.id !== 'haha' && s.id !== 'cxsj') : DOWNLOAD_SOURCES),
     [project]
   );
 


### PR DESCRIPTION
## 下载源清理

根据 #60 和 #59 的要求，整理下载页的下载源列表：

### 变更明细

| 下载源 | 操作 | 原因 |
|--------|------|------|
| GitHub 官方 | ✅ 保留 | 官方发布渠道 |
| 枫源镜像 (haha) | ✅ 保留 | #60 授权确认 |
| 柠泽资源站 (lemwood) | ✅ 保留 | 网站维护者提供 |
| 创想镜像 (cxsj) | 🆕 新增 | #59 由 @239LAN 提供 |
| Fishcpy 加速 (mirror) | ❌ 删除 | 未授权 |
| Foxington 源 (foxington) | ❌ 删除 | 不再维护 |

### 创想镜像技术细节

- URL 格式：`https://mirror.cxsjmc.cn/ZL/ZalithLauncher-latest-{arch}.apk`
- 通用版：`ZalithLauncher-latest.apk`
- 无需 API 调用，URL 按架构确定性拼接
- 仅支持 ZL2（ZL1 无对应镜像，回退到 GitHub）

### 代码变更

- `useLatestRelease.ts`：删除 fishcpy/foxington 的 DOWNLOAD_SOURCES 条目和数据拉取逻辑，新增 cxsj 源
- `Download.tsx`：删除 mirror/foxington 的 URL 拼接逻辑，新增 cxsj 的架构映射逻辑

Closes #59, Closes #60