### PR TITLE
docs: update download sources authorization status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,15 @@ pnpm preview    # 预览构建产物
 
 ## 下载源说明 / Download Sources
 
-下载页聚合多个下载渠道：
+下载页聚合多个下载渠道，所有镜像源均经项目方确认授权后收录（见 #59、#60）：
 
-- **GitHub 官方** — 官方 Release
-- **国内加速** — fishcpy 提供
-- **Foxington 源** — 第三方镜像（仅 ZL1）
-- **枫源镜像** — FrostLynx 提供，主站 [fyhub.cn](https://fyhub.cn)（仅 ZL2，为 ZL2 默认下载源）
-- **柠枺镜像** — Lemwood 提供
+| 下载源 | 提供者 | 支持项目 | 授权情况 |
+|--------|--------|----------|----------|
+| GitHub 官方 | ZalithLauncher 项目方 | ZL1 / ZL2 | 官方渠道 |
+| 枫源镜像 | [FrostLynx](https://frostlynx.work)（主站 [fyhub.cn](https://fyhub.cn)） | 仅 ZL2 | 已授权（#60） |
+| 柠泽资源站 | [Lemwood](https://lemwood.cn) | ZL1 / ZL2 | 已授权（网站维护者提供） |
+| 创想镜像 | [239LAN](https://github.com/239LAN)（主站 [mirror.cxsjmc.cn](https://mirror.cxsjmc.cn)） | 仅 ZL2 | 已授权（#59） |
+
+已下架的下载源：**Fishcpy 加速**（未授权，#60）、**Foxington 源**（已停止维护）。
 
 网页端下载链接统一跳转镜像主站验证页，由主站完成验证与节点调度，前端不直接调用程序下载 API。

--- a/README.md
+++ b/README.md
@@ -42,6 +42,4 @@ pnpm preview    # 预览构建产物
 | 柠泽资源站 | [Lemwood](https://lemwood.cn) | ZL1 / ZL2 | 已授权（网站维护者提供） |
 | 创想镜像 | [239LAN](https://github.com/239LAN)（主站 [mirror.cxsjmc.cn](https://mirror.cxsjmc.cn)） | 仅 ZL2 | 已授权（#59） |
 
-已下架的下载源：**Fishcpy 加速**（未授权，#60）、**Foxington 源**（已停止维护）。
-
 网页端下载链接统一跳转镜像主站验证页，由主站完成验证与节点调度，前端不直接调用程序下载 API。


### PR DESCRIPTION
## README 下载源授权情况更新

配套 #62 的下载源清理，在 README 中记录各下载路线的授权情况。

### 变更内容

将过时的下载源列表（仍包含 fishcpy / Foxington）替换为授权状态表：

| 下载源 | 提供者 | 支持项目 | 授权情况 |
|--------|--------|----------|----------|
| GitHub 官方 | ZalithLauncher 项目方 | ZL1 / ZL2 | 官方渠道 |
| 枫源镜像 | [FrostLynx](https://frostlynx.work)（主站 [fyhub.cn](https://fyhub.cn)） | 仅 ZL2 | 已授权（#60） |
| 柠泽资源站 | [Lemwood](https://lemwood.cn) | ZL1 / ZL2 | 已授权（网站维护者提供） |
| 创想镜像 | [239LAN](https://github.com/239LAN)（主站 [mirror.cxsjmc.cn](https://mirror.cxsjmc.cn)） | 仅 ZL2 | 已授权（#59） |

> 「柠泽资源站」为完整名称；其提供者即官网维护者。

Refs #59, Refs #60